### PR TITLE
Bump version (v1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v1.5.2](https://github.com/NubeIO/rubix-bacnet-server/tree/v1.5.2) (2020-04-20)
+### Added
+- mqtt-rest-bridge replacement with rubix-http
+- Cascade delete points mapping
+
 ## [v1.5.1](https://github.com/NubeIO/rubix-bacnet-server/tree/v1.5.1) (2020-04-12)
 ### Added
 - Fix: On create point next available address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rubix-bacnet"
-version = "1.5.1"
+version = "1.5.2"
 description = "Rubix BACnet"
 authors = ["NubeIO"]
 


### PR DESCRIPTION
### Includes

- mqtt-rest-bridge replacement with rubix-http
- Cascade delete points mapping