### PR TITLE
Add priority to MQTT message

### DIFF
--- a/src/bacnet_server/bac_server.py
+++ b/src/bacnet_server/bac_server.py
@@ -9,7 +9,8 @@ from bacpypes.local.object import Commandable
 
 from src import BACnetSetting
 from src.bacnet_server.feedbacks.analog_output import AnalogOutputFeedbackObject
-from src.bacnet_server.helpers.helper_point_array import default_values, create_object_identifier
+from src.bacnet_server.helpers.helper_point_array import default_values, create_object_identifier, \
+    get_highest_priority_field
 from src.bacnet_server.helpers.helper_point_store import update_point_store
 from src.bacnet_server.interfaces.point.points import PointType
 from src.bacnet_server.models.model_point import BACnetPointModel
@@ -108,8 +109,9 @@ class BACServer(metaclass=Singleton):
         self.__bacnet.this_application.add_object(ao)
         update_point_store(point.uuid, present_value)
         self.__registry[object_identifier] = ao
+        priority = get_highest_priority_field(point.priority_array_write)
         mqtt_client = MqttClient()
-        mqtt_client.publish_value(('ao', object_identifier), present_value)
+        mqtt_client.publish_value(('ao', object_identifier), present_value, priority)
 
     def remove_point(self, point):
         object_identifier = create_object_identifier(point.object_type.name, point.address)

--- a/src/bacnet_server/feedbacks/analog_output.py
+++ b/src/bacnet_server/feedbacks/analog_output.py
@@ -2,7 +2,8 @@ from bacpypes.local.object import AnalogOutputCmdObject
 from bacpypes.primitivedata import Real
 from flask import current_app
 
-from src.bacnet_server.helpers.helper_point_array import create_object_identifier, serialize_priority_array
+from src.bacnet_server.helpers.helper_point_array import create_object_identifier, serialize_priority_array, \
+    get_highest_priority_field
 from src.bacnet_server.helpers.helper_point_store import update_point_store
 from src.bacnet_server.models.model_priority_array import PriorityArrayModel
 from src.mqtt import MqttClient
@@ -18,7 +19,8 @@ class AnalogOutputFeedbackObject(AnalogOutputCmdObject):
         priority_array = self._dict_contents().get('priorityArray')
         serialized_priority_array = serialize_priority_array(priority_array)
         with self.__app_context():
-            PriorityArrayModel.filter_by_point_uuid(self.profileName).update(serialized_priority_array)
+            priority_array_updated = PriorityArrayModel.filter_by_point_uuid(self.profileName).update(
+                serialized_priority_array)
             update_point_store(self.profileName, new_value)
             object_identifier = create_object_identifier(self.objectIdentifier[0], self.objectIdentifier[1])
             present_value = self.presentValue
@@ -26,5 +28,6 @@ class AnalogOutputFeedbackObject(AnalogOutputCmdObject):
                 present_value = float(present_value.value)
             elif type(present_value) is float:
                 present_value = float(present_value)
+            priority = get_highest_priority_field(priority_array_updated)
             mqtt_client = MqttClient()
-            mqtt_client.publish_value(('ao', object_identifier), present_value)
+            mqtt_client.publish_value(('ao', object_identifier), present_value, priority)

--- a/src/bacnet_server/helpers/helper_point_array.py
+++ b/src/bacnet_server/helpers/helper_point_array.py
@@ -13,6 +13,14 @@ def serialize_priority_array(priority_array):
     return priority_array_dict
 
 
+def get_highest_priority_field(priority_array):
+    for i in range(17):
+        value = getattr(priority_array, f'_{i + 1}', None)
+        if value is not None:
+            return i
+    return 16
+
+
 def highest_priority(iterable, _type, default=None):
     if iterable:
         priority = 0

--- a/src/mqtt/mqtt_client.py
+++ b/src/mqtt/mqtt_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from registry.registry import RubixRegistry
@@ -27,8 +28,13 @@ class MqttClient(MqttClientBase, metaclass=Singleton):
         return super().config if isinstance(super().config, MqttSetting) else MqttSetting()
 
     @allow_only_on_prefix
-    def publish_value(self, topic_suffix: tuple, payload: str):
+    def publish_value(self, topic_suffix: tuple, value: str, priority: int):
         if self.config.publish_value:
+            output = {
+                'value': value,
+                'priority': priority
+            }
+            payload = json.dumps(output)
             self.__publish_mqtt_value(self.make_topic((self.config.topic,) + topic_suffix), payload)
 
     @allow_only_on_prefix


### PR DESCRIPTION
Resolves: #127 
### Summary:
- Added `priority` to MQTT message. Example:
  ```
  {"value": "<present_value>", "priority": "<priority>"}
  ```