### PR TITLE
Improvement on update_mapping_state

### DIFF
--- a/src/bacnet_server/models/model_mapping.py
+++ b/src/bacnet_server/models/model_mapping.py
@@ -29,6 +29,10 @@ class BPGPointMapping(ModelBase):
         if not self.mapped_point_uuid:
             self.__set_mapped_point_uuid()
 
+    def set_uuid_with_name(self):
+        self.__set_point_uuid()
+        self.__set_mapped_point_uuid()
+
     def __set_point_name(self):
         from src.bacnet_server.models.model_point import BACnetPointModel
         if not self.point_uuid:

--- a/src/bacnet_server/resources/mapping/mapping.py
+++ b/src/bacnet_server/resources/mapping/mapping.py
@@ -67,7 +67,10 @@ class BPGPMappingResourceUpdateMappingState(RubixResource):
                 mapping.mapping_state = MappingState.MAPPED
                 mapping.check_self()
             except ValueError:
-                mapping.mapping_state = MappingState.BROKEN
+                try:
+                    mapping.set_uuid_with_name()
+                except ValueError:
+                    mapping.mapping_state = MappingState.BROKEN
             mapping.commit()
             sync_point_value(mapping)
         return {"message": "Mapping state has been updated successfully"}


### PR DESCRIPTION
### Summary:
- On `update_mapping_state` API endpoint updated point-uuid via name if broken, and if still name doesn't exist leave as is as broken.